### PR TITLE
chore: actualizar .gitignore para ignorar archivo .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-env
+.env


### PR DESCRIPTION
- Añade `.env` al archivo .gitignore para evitar que se suban cambios no deseados del entorno.
- Asegura que las configuraciones sensibles no se incluyan en el repositorio.